### PR TITLE
Make TZ optional

### DIFF
--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -37,6 +37,7 @@ export const zUser = z.object({
   tz: z
     .string()
     .optional()
+    .nullable()
     .describe("The user's timezone city/location (e.g. America/Chicago)."),
   // tz_label: z
   //   .string()


### PR DESCRIPTION
This will correct this validation error
```
ackages/mcp/shared/session.py", line 286, in send_request
    raise McpError(response_or_error.error)
mcp.shared.exceptions.McpError: MCP error -32602: Invalid structured content for tool getUsers: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "results",
      0,
      "tz"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "results",
      1,
      "tz"
    ],
    "message": "Required"
  }
]
```