### PR TITLE
Fetch the auth.test on startup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,5 @@
 SLACK_BOT_TOKEN=xoxb-
 SLACK_APP_TOKEN=xapp-
-SLACK_DOMAIN=your-workspace-name
 
 # Logfire configuration (https://logfire.pydantic.dev)
 # Get write token from https://logfire.pydantic.dev/your-org/your-project/settings/write-tokens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,6 @@ npm run inspector           # Test with MCP Inspector
 # Slack API credentials
 SLACK_BOT_TOKEN="xoxb-..."
 SLACK_APP_TOKEN="xapp-..."
-SLACK_DOMAIN="your-workspace"
 
 # PostgreSQL connection details
 PGHOST="db"                    # or "localhost" for local development
@@ -171,21 +170,6 @@ If `LOGFIRE_TOKEN` is blank in `.env`:
   }
 }
 ```
-
-**Interactive Slack App Setup:**
-1. Run: `open https://api.slack.com/apps/`
-2. Instruct: "Click 'Create New App' → 'From a manifest' → Choose your workspace"
-3. Prompt user: "What is your workspace name? (for SLACK_DOMAIN)"
-4. Update `SLACK_DOMAIN` in `.env` with workspace name
-5. Instruct: "Paste the manifest above, then click 'Next' and 'Create'"
-6. Instruct: "Navigate to: Basic Information → App-Level Tokens"
-7. Instruct: "Click 'Generate Token and Scopes' → Add 'connections:write' scope → Generate"
-8. Prompt user: "Please paste your App-Level Token (starts with 'xapp-'):"
-9. Update `SLACK_APP_TOKEN` in `.env` with provided token
-10. Instruct: "Navigate to: Install App → Click 'Install to [Workspace]'"
-11. Instruct: "After installation, copy the 'Bot User OAuth Token'"
-12. Prompt user: "Please paste your Bot User OAuth Token (starts with 'xoxb-'):"
-13. Update `SLACK_BOT_TOKEN` in `.env` with provided token
 
 ### 4. Service Startup
 Run services and verify health:

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -85,7 +85,6 @@ The app subscribes to these Slack events for real-time ingestion:
    ```bash
    SLACK_BOT_TOKEN="xoxb-your-bot-token"
    SLACK_APP_TOKEN="xapp-your-app-token"
-   SLACK_DOMAIN="your-workspace-name"
    ```
 
 ### Running the Ingest Service

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -4,11 +4,14 @@ import { cliEntrypoint } from './shared/boilerplate/src/cliEntrypoint.js';
 
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { initWorkspaceBaseUrl } from './util/addMessageLinks.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: join(__dirname, '../../.env') });
 
-cliEntrypoint(
-  join(__dirname, 'stdio.js'),
-  join(__dirname, 'httpServer.js'),
-).catch(console.error);
+initWorkspaceBaseUrl().finally(() =>
+  cliEntrypoint(
+    join(__dirname, 'stdio.js'),
+    join(__dirname, 'httpServer.js'),
+  ).catch(console.error),
+);

--- a/mcp/src/util/addMessageLinks.ts
+++ b/mcp/src/util/addMessageLinks.ts
@@ -19,10 +19,7 @@ export const initWorkspaceBaseUrl = async (): Promise<void> => {
     const data = await response.json();
 
     if (!data.ok) {
-      log.warn(
-        'An error occurred while getting the Slack url base. Will not return permalinks.',
-        { data },
-      );
+      throw new Error('auth.test request failed.');
     }
 
     workspaceBaseUrl = data?.url || null;

--- a/mcp/src/util/addMessageLinks.ts
+++ b/mcp/src/util/addMessageLinks.ts
@@ -1,7 +1,40 @@
+import { log } from '../shared/boilerplate/src/logger.js';
 import { Message } from '../types.js';
 import { convertTimestampToTs } from './formatTs.js';
 
-const SLACK_DOMAIN = process.env.SLACK_DOMAIN;
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
+
+let workspaceBaseUrl: string | null;
+
+export const initWorkspaceBaseUrl = async (): Promise<void> => {
+  try {
+    const response = await fetch('https://slack.com/api/auth.test', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    if (!data.ok) {
+      log.warn(
+        'An error occurred while getting the Slack url base. Will not return permalinks.',
+        { data },
+      );
+    }
+
+    workspaceBaseUrl = data?.url || null;
+    log.info(`Permalink base url: ${workspaceBaseUrl}`);
+  } catch (err) {
+    log.error(
+      'An error occurred while getting the Slack url base. Will not return permalinks.',
+      err as Error,
+    );
+    workspaceBaseUrl = null;
+  }
+};
 
 export const generatePermalink = (message: Message): string | undefined => {
   const messageTs = convertTimestampToTs(message.ts, true);
@@ -9,6 +42,10 @@ export const generatePermalink = (message: Message): string | undefined => {
     ? convertTimestampToTs(message.thread_ts)
     : null;
 
-  if (messageTs)
-    return `https://${SLACK_DOMAIN}.slack.com/archives/${message.channel_id}/p${messageTs}${threadTs ? `?thread_ts=${threadTs}` : ''}`;
+  if (messageTs && workspaceBaseUrl) {
+    return new URL(
+      `/archives/${message.channel_id}/p${messageTs}${threadTs ? `?thread_ts=${threadTs}` : ''}`,
+      workspaceBaseUrl,
+    ).toString();
+  }
 };

--- a/setup-tiger-slack.sh
+++ b/setup-tiger-slack.sh
@@ -12,7 +12,6 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Token storage - using regular variables instead of associative array for compatibility
-SLACK_DOMAIN_VAL=""
 SLACK_BOT_TOKEN_VAL=""
 SLACK_APP_TOKEN_VAL=""
 LOGFIRE_TOKEN_VAL=""
@@ -120,14 +119,6 @@ create_slack_app() {
 
     echo "1. Click 'Create New App' → 'From a manifest' → Choose your workspace"
 
-    # Ask for workspace name only on first app creation
-    if [[ -z "$SLACK_DOMAIN_VAL" ]]; then
-        echo ""
-        read -p "What is your Slack workspace name? (for SLACK_DOMAIN): " slack_domain
-        SLACK_DOMAIN_VAL="$slack_domain"
-        echo ""
-    fi
-
     read -p "Press Enter after selecting your workspace and clicking Next..."
 
     # Show manifest file content
@@ -208,7 +199,6 @@ write_env_file() {
 
     # Update tokens
     local token_vars=(
-        "SLACK_DOMAIN:$SLACK_DOMAIN_VAL"
         "SLACK_BOT_TOKEN:$SLACK_BOT_TOKEN_VAL"
         "SLACK_APP_TOKEN:$SLACK_APP_TOKEN_VAL"
         "LOGFIRE_TOKEN:$LOGFIRE_TOKEN_VAL"


### PR DESCRIPTION
This removes the need to store the 'slack_domain' environment variable. Instead, the MCP server just fetches the `auth.test` from Slack's API on startup and uses that to generate the permalinks.

### Demo
#### mcp inspector
<img width="871" height="932" alt="image" src="https://github.com/user-attachments/assets/7438442d-1696-4d26-9ae8-4bb28bfbb728" />

#### logs
<img width="887" height="191" alt="image" src="https://github.com/user-attachments/assets/466f2b0f-23f6-4532-acf2-00d1b25a5b86" />

#### setup script (removal of prompt)
<img width="607" height="256" alt="image" src="https://github.com/user-attachments/assets/91f4fd28-a6a0-444b-8e52-a50e72238bbc" />

### Related PRs
https://github.com/timescale/tiger-eon/pull/31
https://github.com/timescale/tiger-agents-deploy/pull/20

Fixes #29 