### PR TITLE
cd: fix build-and-deploy-on-merge workflows

### DIFF
--- a/.github/workflows/build-and-deploy-ingest-on-merge.yml
+++ b/.github/workflows/build-and-deploy-ingest-on-merge.yml
@@ -16,8 +16,8 @@ jobs:
           owner: timescale
           repo: tiger-agents-deploy
           workflow_id: build.yaml
-          ref: "main"
-          inputs: '{"dockerfile_path": "./ingest/Dockerfile", "image_name": "tiger-slack-ingest", "repository": "tiger-slack", "sha": "${{ github.sha }}"}'
+          ref: "mpeveler/feat-docker-context"
+          inputs: '{"docker_context": "./ingest", "image_name": "tiger-slack-ingest", "repository": "tiger-slack", "sha": "${{ github.sha }}"}'
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy-mcp-on-merge.yml
+++ b/.github/workflows/build-and-deploy-mcp-on-merge.yml
@@ -16,8 +16,8 @@ jobs:
           owner: timescale
           repo: tiger-agents-deploy
           workflow_id: build.yaml
-          ref: "main"
-          inputs: '{"dockerfile_path": "./mcp/Dockerfile", "image_name": "tiger-slack-mcp-server", "repository": "tiger-slack", "sha": "${{ github.sha }}"}'
+          ref: "mpeveler/feat-docker-context"
+          inputs: '{"docker_context": "./mcp", "image_name": "tiger-slack-mcp-server", "repository": "tiger-slack", "sha": "${{ github.sha }}"}'
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR updates the `build-and-deploy-*-on-merge` workflows so that we:

1. Use the `mpeveler/feat-docker-context` branch for tiger-agents-deploy while https://github.com/timescale/tiger-agents-deploy/pull/18 is not yet merged
2. Uses the `docker_context` input to set the build context folder

This matches what we did with the `build-*-on-feature-branch` workflows that were added in #27 