### PR TITLE
cd: add build on merge if workflows change

### DIFF
--- a/.github/workflows/build-and-deploy-ingest-on-merge.yml
+++ b/.github/workflows/build-and-deploy-ingest-on-merge.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "ingest/**"
+      - .github/workflows/*ingest*
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy-mcp-on-merge.yml
+++ b/.github/workflows/build-and-deploy-mcp-on-merge.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "mcp/**"
+      - .github/workflows/*mcp*
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR makes it so that the `build-and-deploy-*-on-merge.yml` workflows will run the workflow itself was changed. This is so that if we made a workflow change and we needed the build, we wouldn't need to make a dummy commit into the `ingest` or `mcp` subfolder as well.

We made a similar change in #34 for the `build-*-on-feature-branch.yml` workflows for the same reason.