### PR TITLE
refactor: utilize multiple workers for slack import

### DIFF
--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiocron>=2.1",
+    "aiofiles>=24.1.0",
     "aiohttp>=3.12.15",
     "click>=8.2.1",
     "logfire[psycopg,system-metrics]>=4.10.0",

--- a/ingest/uv.lock
+++ b/ingest/uv.lock
@@ -17,6 +17,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -759,6 +768,7 @@ name = "tiger-slack"
 source = { editable = "." }
 dependencies = [
     { name = "aiocron" },
+    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "click" },
     { name = "logfire", extra = ["psycopg", "system-metrics"] },
@@ -778,6 +788,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiocron", specifier = ">=2.1" },
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.12.15" },
     { name = "click", specifier = ">=8.2.1" },
     { name = "logfire", extras = ["psycopg", "system-metrics"], specifier = ">=4.10.0" },


### PR DESCRIPTION
PR builds upon #37 and further improves the import efficiency by implementing parallel asyncio workers to process files. Instead of going file by file, we now construct a list of all files into memory and insert it into an `asyncio.Queue`. We then spin up 5 asyncio tasks that pick off files off the queue and import once we hit a certain item count. I found with this improvement, my local import took `5:48.91 total` (so an improvement of ~3 minutes over #37) and then importing to a remote server took `17:53.52 total` (with #37 took ~48 minutes (as measured by real clock) and before that took ~3 hours).

Note, all times were measured via using `time uv run python -m tiger_slack.import ../slack_export` (both here and #37).

When reviewing the code, I would recommend disabling viewing whitespace changes.