### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 .claude
 .mcp.json
+.DS_Store
+slack_export/


### PR DESCRIPTION
PR adds the following two new rules to `.gitignore`:

* `.DS_Store`, self-explanatory for anyone who uses macos I think
* `slack_export/` was the folder name I was using for the full slack export I got to test the import script, don't want to risk checking in the folder by accident, and also VSCode was complaining about the number of changes in git before I ignored it.