### PR TITLE
chore: fix channel_name

### DIFF
--- a/mcp/src/apis/getChannels.ts
+++ b/mcp/src/apis/getChannels.ts
@@ -37,7 +37,7 @@ export const getChannelsFactory: ApiFactory<
   fn: async ({ keyword }): Promise<{ results: z.infer<typeof zChannelWithoutMessages>[] }> => {
     const res = await pgPool.query(
       /* sql */ `
-SELECT id, channel_name, topic, purpose
+SELECT id, name, topic, purpose
   FROM slack.channel
   WHERE NOT is_archived
   AND (

--- a/mcp/src/util/addChannelInfo.ts
+++ b/mcp/src/util/addChannelInfo.ts
@@ -13,7 +13,7 @@ export const addChannelInfo = async (
 ): Promise<void> => {
   const channelsResult = await client.query(
     /* sql */ `
-SELECT id, channel_name, topic, purpose
+SELECT id, name, topic, purpose
   FROM slack.channel
   WHERE id = ANY($1)`,
     [Object.keys(channels)],

--- a/mcp/src/util/findChannel.ts
+++ b/mcp/src/util/findChannel.ts
@@ -13,7 +13,7 @@ export const findChannel = async (
 ): Promise<Channel[]> => {
   const res = await pgPool.query(
     /* sql */ `
-SELECT id, channel_name, topic, purpose
+SELECT id, name, topic, purpose
   FROM slack.channel
   WHERE
     (


### PR DESCRIPTION
it's been renamed even though I don't see it in migrations.