### PR TITLE
[CHORE] Remove redundant column store policy from `slack.event`

### DIFF
--- a/ingest/tiger_slack/migrations/incremental/000-event.sql
+++ b/ingest/tiger_slack/migrations/incremental/000-event.sql
@@ -23,6 +23,5 @@ create index on slack.event (event_ts desc) where error is not null;
 create index on slack.event (type, subtype);
 create index on slack.event (id);
 
-call public.add_columnstore_policy('slack.event'::regclass, after => interval '7 days');
 perform public.add_retention_policy('slack.event'::regclass, interval '90 days');
 


### PR DESCRIPTION
Since the table already has 
```sql
, tsdb.chunk_interval='7 days'
, tsdb.enable_columnstore=true
```
we shouldn't need the explicit call to enable the columnstore 

See [thread](https://iobeam.slack.com/archives/C09AF06P37B/p1762204098253479)