### PR TITLE
Fix MCP tools/list failure from unrepresentable Date schema

### DIFF
--- a/mcp/src/apis/getConversationsInChannel.ts
+++ b/mcp/src/apis/getConversationsInChannel.ts
@@ -71,12 +71,7 @@ WHERE channel_id = $1
   AND ($3::TIMESTAMPTZ IS NULL OR ts <= $3::TIMESTAMPTZ)
 ORDER BY ts DESC
 LIMIT $4`,
-        [
-          targetChannel.id,
-          timestampStart?.toISOString(),
-          timestampEnd?.toISOString(),
-          limit || 1000,
-        ],
+        [targetChannel.id, timestampStart, timestampEnd, limit || 1000],
       );
 
       const { involvedUsers, channels } = messagesToTree(

--- a/mcp/src/apis/getConversationsWithUser.ts
+++ b/mcp/src/apis/getConversationsWithUser.ts
@@ -70,13 +70,7 @@ export const getConversationsWithUserFactory: ApiFactory<
           '$5',
           includeFiles,
         ),
-        [
-          user.id,
-          timestampStart?.toISOString(),
-          timestampEnd?.toISOString(),
-          window || 5,
-          limit || 1000,
-        ],
+        [user.id, timestampStart, timestampEnd, window || 5, limit || 1000],
       );
 
       const { channels, involvedUsers } = messagesToTree(

--- a/mcp/src/apis/search.ts
+++ b/mcp/src/apis/search.ts
@@ -21,11 +21,11 @@ const inputSchema = {
       .min(1)
       .nullable()
       .describe('The maximum number of messages to return. Defaults to 20.'),
-    timestampStart: z.coerce
-      .date()
+    timestampStart: z.iso
+      .datetime({ offset: true })
       .nullable()
       .describe(
-        'Optional start date for the message range. Defaults to null, which means that search will be against all historic messages.',
+        'Optional start date for the message range, as an ISO 8601 datetime string. Defaults to null, which means that search will be against all historic messages.',
       ),
   }).shape,
   channels: z
@@ -131,8 +131,8 @@ export const searchFactory: ApiFactory<
         [
           userIdsToFilterOn,
           channelIdsToFilterOn,
-          timestampStart?.toISOString(),
-          timestampEnd?.toISOString(),
+          timestampStart,
+          timestampEnd,
           type === 'semantic' ? JSON.stringify(embedding?.embedding) : keyword,
           limit * 3,
         ],

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -160,17 +160,17 @@ export const zMessageFilter = z.object({
 export type MessageFilter = z.infer<typeof zMessageFilter>;
 
 export const zTimeFilters = z.object({
-  timestampStart: z.coerce
-    .date()
+  timestampStart: z.iso
+    .datetime({ offset: true })
     .nullable()
     .describe(
-      'Optional start date for the message range. Defaults to rangeEnd - 1w.',
+      'Optional start date for the message range, as an ISO 8601 datetime string. Defaults to rangeEnd - 1w.',
     ),
-  timestampEnd: z.coerce
-    .date()
+  timestampEnd: z.iso
+    .datetime({ offset: true })
     .nullable()
     .describe(
-      'Optional end date for the message range. Defaults to the current time.',
+      'Optional end date for the message range, as an ISO 8601 datetime string. Defaults to the current time.',
     ),
 });
 


### PR DESCRIPTION
## Problem

The Slack MCP server was failing on `tools/list` with the error:

> Date cannot be represented in JSON Schema

The MCP SDK converts each tool's Zod input schema to JSON Schema (via Zod 4's `toJSONSchema` with `unrepresentable: 'throw'`) when building the `tools/list` response. The `timestampStart` / `timestampEnd` fields used `z.coerce.date()`, which produces a `ZodDate`. `ZodDate` has no JSON Schema representation, so serialization threw and broke the **entire** tool listing — making every tool unavailable.

This was a latent bug surfaced by recent dependency bumps.

## Fix

Replace `z.coerce.date()` with `z.iso.datetime({ offset: true })` for the timestamp input fields. This:

- Accepts an ISO 8601 datetime **string**, which serializes cleanly to JSON Schema (`type: "string", format: "date-time"`).
- Passes the string straight to Postgres — the SQL already casts the parameter with `$N::TIMESTAMPTZ` — so the now-unnecessary `?.toISOString()` calls were removed.

### Files changed
- `mcp/src/types.ts` — `zTimeFilters` schema
- `mcp/src/apis/search.ts` — `timestampStart` schema override + query args
- `mcp/src/apis/getConversationsInChannel.ts` — query args
- `mcp/src/apis/getConversationsWithUser.ts` — query args

## Behavior note

`z.iso.datetime()` validates the string format strictly, so callers must pass valid ISO 8601 datetimes (e.g. `2024-01-01T00:00:00Z`) rather than the looser strings `z.coerce.date()` previously accepted. Since these tools are invoked by LLMs, the explicit, well-described contract is an improvement.

## Verification
- `typecheck` passes
- `lint` passes
- Confirmed `z.toJSONSchema(..., { unrepresentable: 'throw' })` no longer throws on the new schema
